### PR TITLE
changed migration index names from symbols to strings

### DIFF
--- a/db/migrate/20100405201417_create_tr8n_tables.rb
+++ b/db/migrate/20100405201417_create_tr8n_tables.rb
@@ -151,7 +151,7 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.string  :source
       t.timestamps
     end
-    add_index :tr8n_translation_sources, [:source], :name => :tr8n_sources_source
+    add_index :tr8n_translation_sources, [:source], :name => "tr8n_sources_source"
 
     create_table :tr8n_translation_key_sources do |t|
       t.integer :translation_key_id, :null => false
@@ -159,8 +159,8 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.text    :details
       t.timestamps
     end
-    add_index :tr8n_translation_key_sources, [:translation_key_id], :name => :tr8n_trans_keys_key_id
-    add_index :tr8n_translation_key_sources, [:translation_source_id], :name => :tr8n_trans_keys_source_id
+    add_index :tr8n_translation_key_sources, [:translation_key_id], :name => "tr8n_trans_keys_key_id"
+    add_index :tr8n_translation_key_sources, [:translation_source_id], :name => "tr8n_trans_keys_source_id"
 
     create_table :tr8n_translation_key_locks do |t|
       t.integer :translation_key_id, :null => false
@@ -169,7 +169,7 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.boolean :locked, :default => false
       t.timestamps
     end
-    add_index :tr8n_translation_key_locks, [:translation_key_id, :language_id], :name => :tr8n_locks_key_id_lang_id
+    add_index :tr8n_translation_key_locks, [:translation_key_id, :language_id], :name => "tr8n_locks_key_id_lang_id"
 
     create_table :tr8n_translations do |t|
       t.integer :translation_key_id,  :null => false
@@ -181,9 +181,9 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.text    :rules      
       t.timestamps
     end
-    add_index :tr8n_translations, [:translator_id], :name => :tr8n_trans_translator_id
-    add_index :tr8n_translations, [:translation_key_id, :translator_id, :language_id], :name => :tr8n_trans_key_id_translator_id_lang_id
-    add_index :tr8n_translations, [:created_at], :name => :tr8n_trans_created_at
+    add_index :tr8n_translations, [:translator_id], :name => "r8n_trans_translator_id"
+    add_index :tr8n_translations, [:translation_key_id, :translator_id, :language_id], :name => "tr8n_trans_key_id_translator_id_lang_id"
+    add_index :tr8n_translations, [:created_at], :name => "tr8n_trans_created_at"
   
     create_table :tr8n_translation_votes do |t|
       t.integer :translation_id,      :null => false
@@ -191,8 +191,8 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.integer :vote,                :null => false
       t.timestamps
     end
-    add_index :tr8n_translation_votes, [:translator_id], :name => :tr8n_trans_votes_translator_id
-    add_index :tr8n_translation_votes, [:translation_id, :translator_id], :name => :tr8n_trans_votes_trans_id_translator_id
+    add_index :tr8n_translation_votes, [:translator_id], :name => "tr8n_trans_votes_translator_id"
+    add_index :tr8n_translation_votes, [:translation_id, :translator_id], :name => "tr8n_trans_votes_trans_id_translator_id"
 
     create_table :tr8n_glossary do |t|
       t.string  :keyword
@@ -207,8 +207,8 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.text    :topic, :null => false
       t.timestamps
     end
-    add_index :tr8n_language_forum_topics, [:language_id], :name => :tr8n_forum_topics_lang_id
-    add_index :tr8n_language_forum_topics, [:translator_id], :name => :tr8n_forum_topics_translator_id
+    add_index :tr8n_language_forum_topics, [:language_id], :name => "tr8n_forum_topics_lang_id"
+    add_index :tr8n_language_forum_topics, [:translator_id], :name => "tr8n_forum_topics_translator_id"
     
     create_table :tr8n_language_forum_messages do |t|
       t.integer :language_id, :null => false
@@ -217,9 +217,9 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.text    :message, :null => false
       t.timestamps
     end
-    add_index :tr8n_language_forum_messages, [:language_id], :name => :tr8n_forum_msgs_lang_id
-    add_index :tr8n_language_forum_messages, [:translator_id], :name => :tr8n_forums_msgs_translator_id
-    add_index :tr8n_language_forum_messages, [:language_id, :language_forum_topic_id], :name => :tr8n_forum_msgs_lang_id_topic_id
+    add_index :tr8n_language_forum_messages, [:language_id], :name => "tr8n_forum_msgs_lang_id"
+    add_index :tr8n_language_forum_messages, [:translator_id], :name => "tr8n_forums_msgs_translator_id"
+    add_index :tr8n_language_forum_messages, [:language_id, :language_forum_topic_id], :name => "tr8n_forum_msgs_lang_id_topic_id"
     
     create_table :tr8n_language_forum_abuse_reports do |t|
       t.integer :language_id, :null => false
@@ -228,9 +228,9 @@ class CreateTr8nTables < ActiveRecord::Migration
       t.string  :reason
       t.timestamps
     end
-    add_index :tr8n_language_forum_abuse_reports, [:language_id], :name => :tr8n_forum_reports_lang_id
-    add_index :tr8n_language_forum_abuse_reports, [:language_id, :translator_id], :name => :tr8n_forum_reports_lang_id_translator_id
-    add_index :tr8n_language_forum_abuse_reports, [:language_forum_message_id], :name => :tr8n_forum_reports_message_id
+    add_index :tr8n_language_forum_abuse_reports, [:language_id], :name => "tr8n_forum_reports_lang_id"
+    add_index :tr8n_language_forum_abuse_reports, [:language_id, :translator_id], :name => "tr8n_forum_reports_lang_id_translator_id"
+    add_index :tr8n_language_forum_abuse_reports, [:language_forum_message_id], :name => "tr8n_forum_reports_message_id"
   end
 
   def self.down

--- a/db/migrate/20100813205008_create_tr8n_translation_key_comments.rb
+++ b/db/migrate/20100813205008_create_tr8n_translation_key_comments.rb
@@ -7,9 +7,9 @@ class CreateTr8nTranslationKeyComments < ActiveRecord::Migration
       t.text    :message, :null => false
       t.timestamps
     end
-    add_index :tr8n_translation_key_comments, [:language_id], :name => :tr8n_tkey_msgs_lang_id
-    add_index :tr8n_translation_key_comments, [:translator_id], :name => :tr8n_tkey_msgs_translator_id
-    add_index :tr8n_translation_key_comments, [:language_id, :translation_key_id], :name => :tr8n_tkey_msgs_lang_id_tkey_id
+    add_index :tr8n_translation_key_comments, [:language_id], :name => "tr8n_tkey_msgs_lang_id"
+    add_index :tr8n_translation_key_comments, [:translator_id], :name => "tr8n_tkey_msgs_translator_id"
+    add_index :tr8n_translation_key_comments, [:language_id, :translation_key_id], :name => "tr8n_tkey_msgs_lang_id_tkey_id"
   end
 
   def self.down

--- a/db/migrate/20100826002346_create_tr8n_language_case_rules.rb
+++ b/db/migrate/20100826002346_create_tr8n_language_case_rules.rb
@@ -8,9 +8,9 @@ class CreateTr8nLanguageCaseRules < ActiveRecord::Migration
       t.text    :definition, :null => false
       t.timestamps
     end
-    add_index :tr8n_language_case_rules, [:language_case_id], :name => :tr8n_lcr_case_id
-    add_index :tr8n_language_case_rules, [:language_id], :name => :tr8n_lcr_lang_id
-    add_index :tr8n_language_case_rules, [:translator_id], :name => :tr8n_lcr_translator_id
+    add_index :tr8n_language_case_rules, [:language_case_id], :name => "tr8n_lcr_case_id"
+    add_index :tr8n_language_case_rules, [:language_id], :name => "tr8n_lcr_lang_id"
+    add_index :tr8n_language_case_rules, [:translator_id], :name => "tr8n_lcr_translator_id"
   end
 
   def self.down


### PR DESCRIPTION
I don't have a very deep understanding of why I had to do this, but the included migrations wouldn't run on my system. They failed with errors like:

undefined method `length' for :tr8n_sources_source:Symbol

After changing these to symbols the migrations ran fine and I have a working tr8n system to play with.
Rails version: 2.3.9
Ruby version: 1.8.7

--Stephen
