### PR TITLE
Ajax requests should contain X-Requested-With headers

### DIFF
--- a/public/tr8n/javascripts/tr8n.js
+++ b/public/tr8n/javascripts/tr8n.js
@@ -728,6 +728,7 @@ Tr8n.Utils = {
     }
 
     request.open(options.method, url, true);
+    request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
     request.setRequestHeader('Accept', 'text/javascript, text/html, application/xml, text/xml, */*');
     request.send(options.parameters);


### PR DESCRIPTION
This little update adds X-Requested-With to ajax request headers so that we can determine what's an Ajax request and what is not from the rails app using request.xhr?
