### PR TITLE
There could be a redirect vulnerability here or even XSS. For example if...

### DIFF
--- a/app/controllers/tr8n/base_controller.rb
+++ b/app/controllers/tr8n/base_controller.rb
@@ -108,7 +108,11 @@ module Tr8n
     helper_method :tr8n_features_tabs
 
     def redirect_to_source
-      return redirect_to(params[:source_url]) unless params[:source_url].blank?
+      # Do not allow redirects to external websites
+      escaped_origin_host = Regexp.escape("#{request.protocol}#{request.host}")
+      if(!params[:source_url].blank? && params[:source_url] =~ /^#{escaped_origin_host}/)
+        return redirect_to(params[:source_url])
+      end
       return redirect_to(request.env['HTTP_REFERER']) unless request.env['HTTP_REFERER'].blank?
       redirect_to_site_default_url
     end


### PR DESCRIPTION
... source url is set to "%64%61%74%61%3a%74%65%78%74%2f%68%74%6d%6c%3b%62%61%73%65%36%34%2c%50%48%4e%6a%63%6d%6c%77%64%44%35%68%62%47%56%79%64%43%67%6e%57%46%4e%54%4a%79%6b%38%4c%33%4e%6a%63%6d%6c%77%64%44%34%4b", javascript could get executed.

Prevent that by making sure protocol and hostname in the redirected url match the current protocol and host.
