### PR TITLE
Avoid database exceptions by validating input parameters.

### DIFF
--- a/app/controllers/tr8n/admin/translation_key_controller.rb
+++ b/app/controllers/tr8n/admin/translation_key_controller.rb
@@ -66,19 +66,22 @@ class Tr8n::Admin::TranslationKeyController < Tr8n::Admin::BaseController
   
   def lb_merge
     @keys = params[:keys] || ''
-    @keys = @keys.split(',')
-    @keys = Tr8n::TranslationKey.find(:all, :conditions => ["id in (?)", @keys])
+    @keys = @keys.split(',').select { |id| id =~ /^\d+$/ }
+    @keys = Tr8n::TranslationKey.find(:all, :conditions => ["id in (?)", @keys]) unless @keys.empty?
     @key = @keys.first
     
     render :layout => false
   end
 
   def merge
+    redirect_to_source unless (params[:translation_key] && params[:translation_key][:id])
     master_key = Tr8n::TranslationKey.find_by_id(params[:translation_key].delete(:id))
     
     keys = params[:keys] || ''
-    keys = keys.split(',')
-    keys = Tr8n::TranslationKey.find(:all, :conditions => ["id in (?)", keys])
+    keys = keys.split(',').select { |id| id =~ /^\d+$/ }
+    redirect_to_source if keys.empty?
+    
+    keys = Tr8n::TranslationKey.find(:all, :conditions => ["id in (?)", keys]) 
     keys.each do |key|
       next if key.id == master_key.id
       key.translations.each do |translation|


### PR DESCRIPTION
Those changes originate from a security pen test. By submitting empty or malformed parameters, the tester managed to generate postgres exceptions. Some validation of the input parameters before passing them to ActiveRecord avoids those errors.
