### PR TITLE
Allow using tr() in background jobs (e.g. delayed_job)

### DIFF
--- a/lib/tr8n/extensions/action_view_extension.rb
+++ b/lib/tr8n/extensions/action_view_extension.rb
@@ -102,8 +102,10 @@ module Tr8n
       end
 
       options.merge!(:caller => caller)
-      options.merge!(:url => request.url)
-      options.merge!(:host => request.env['HTTP_HOST'])
+      if request
+        options.merge!(:url => request.url)
+        options.merge!(:host => request.env['HTTP_HOST'])
+      end
 
       unless Tr8n::Config.enabled?
         return Tr8n::TranslationKey.substitute_tokens(label, tokens, options)


### PR DESCRIPTION
E.g. when sending emails.
