### PR TITLE
Fix threshold exception

### DIFF
--- a/app/models/tr8n/language.rb
+++ b/app/models/tr8n/language.rb
@@ -379,7 +379,7 @@ class Tr8n::Language < ActiveRecord::Base
   end
   
   def threshold
-    super || Tr8n::Config.translation_threshold
+    Tr8n::Config.translation_threshold
   end
 
 end


### PR DESCRIPTION
When trying to do "tr(some string)"
I am getting the error
`super: no superclass method `threshold' for #<Tr8n::Language:0xd3b6ebc>`

What is super intent in that call? When is it necessary?

PS: Ruby is relatively new to me so please forgive me if I said something stupid :)
