### PR TITLE
Avoid the creation of translation keys for admin panel if enable_admin_t...

### DIFF
--- a/lib/tr8n/extensions/action_view_extension.rb
+++ b/lib/tr8n/extensions/action_view_extension.rb
@@ -118,7 +118,7 @@ module Tr8n
           trl(label, desc, tokens, options)
         end
       else
-        label
+        Tr8n::TranslationKey.substitute_tokens(label, tokens, options).tr8n_translated.html_safe
       end
     end
     

--- a/lib/tr8n/extensions/action_view_extension.rb
+++ b/lib/tr8n/extensions/action_view_extension.rb
@@ -118,7 +118,7 @@ module Tr8n
           trl(label, desc, tokens, options)
         end
       else
-        Tr8n::Config.default_language.translate(label, desc, tokens, options)
+        label
       end
     end
     


### PR DESCRIPTION
Avoid the creation of translation keys for admin panel if enable_admin_translations is set to false
